### PR TITLE
Improve servername completion when YAML is invalid

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -104,18 +104,23 @@ connection.onCompletion((params) => {
 
   let suggestions: CompletionItem[] = [];
 
+  const text = doc.getText();
   let yamlData: any;
   try {
-    yamlData = jsYaml.load(doc.getText());
+    yamlData = jsYaml.load(text);
   } catch {
     yamlData = null;
   }
 
-  if (
-    typeof yamlData === "object" &&
-    yamlData !== null &&
-    !("servername" in yamlData)
-  ) {
+  let hasServerName = false;
+  if (typeof yamlData === "object" && yamlData !== null) {
+    hasServerName = Object.prototype.hasOwnProperty.call(yamlData, "servername");
+  } else {
+    const regex = /^\s*servername\s*:/m;
+    hasServerName = regex.test(text);
+  }
+
+  if (!hasServerName) {
     suggestions.push({
       label: "servername",
       kind: CompletionItemKind.Property,


### PR DESCRIPTION
## Summary
- offer completion for `servername` even when YAML can't be parsed

## Testing
- `npm run compile`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68440ac953608324b78c3f39c62f5b1c