### PR TITLE
Fix hover feature for servername

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -22,6 +22,7 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
     capabilities: {
       textDocumentSync: TextDocumentSyncKind.Incremental,
       completionProvider: { triggerCharacters: [":", '"'] },
+      hoverProvider: true,
     },
   };
 });
@@ -141,7 +142,7 @@ connection.onHover((params) => {
   if (!doc) return undefined;
   const position = params.position;
   const text = doc.getText();
-  const lines = text.split(/r?\n/);
+  const lines = text.split(/\r?\n/);
   const hoverLine = lines[position.line];
   if (/^\s*servername\s*:/.test(hoverLine)) {
     return {


### PR DESCRIPTION
## Summary
- enable hoverProvider capability
- fix newline regex in hover handler

## Testing
- `yarn test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68440d4cb19883249dcbf954859f5fd6